### PR TITLE
Install dynamic-rest as git egg

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -13,7 +13,9 @@ RUN apk update \
   # Translations dependencies
   && apk add gettext \
   # https://docs.djangoproject.com/en/dev/ref/django-admin/#dbshell
-  && apk add postgresql-client
+  && apk add postgresql-client{%- if cookiecutter.dynamic_rest == "y" %} \
+  # git
+  && apk add --no-cache git{%- endif %}
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -9,7 +9,9 @@ RUN apk update \
   # Pillow dependencies
   && apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev \
   # CFFI dependencies
-  && apk add libffi-dev py-cffi
+  && apk add libffi-dev py-cffi{%- if cookiecutter.dynamic_rest == "y" %} \
+  # git
+  && apk add --no-cache git{%- endif %}
 
 RUN addgroup -S django \
     && adduser -S -G django django

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -38,6 +38,5 @@ djangorestframework-jsonapi==2.7.0  # https://github.com/django-json-api/django-
 {%- endif %}
 
 {%- if cookiecutter.dynamic_rest == "y" %}
-# dynamic-rest==1.9.2 # https://github.com/AltSchool/dynamic-rest
--e git+https://github.com/AltSchool/dynamic-rest.git@v1.9.3#egg=dynamic-rest
+-e git://github.com/AltSchool/dynamic-rest.git@v1.9.3#egg=dynamic-rest
 {%- endif %}


### PR DESCRIPTION
Addresses the concern with the latest dynamic-rest not yet released raised in https://github.com/Oppoin/cookiecutter-django/pull/1.